### PR TITLE
Add custom ore mine rocks and drop configuration

### DIFF
--- a/CustomMineRockRegistry.cs
+++ b/CustomMineRockRegistry.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+using UnityEngine;
+
+namespace TestOresIngots;
+
+internal sealed record CustomMineRockDefinition(
+    string PrefabName,
+    string DropItemPrefabName,
+    float DropChance,
+    int StackMin,
+    int StackMax,
+    int RequiredToolTier);
+
+internal static class CustomMineRockRegistry
+{
+    private static readonly List<CustomMineRockDefinition> Definitions = new();
+
+    public static void Register(string prefabName, string dropItemPrefabName, float dropChance, int stackMin, int stackMax, int requiredToolTier)
+    {
+        if (string.IsNullOrWhiteSpace(prefabName) || string.IsNullOrWhiteSpace(dropItemPrefabName))
+        {
+            return;
+        }
+
+        int sanitizedMin = Mathf.Max(1, stackMin);
+        int sanitizedMax = Mathf.Max(sanitizedMin, stackMax);
+        float sanitizedChance = Mathf.Clamp01(dropChance);
+        int sanitizedTier = Mathf.Max(0, requiredToolTier);
+
+        Definitions.RemoveAll(definition => definition.PrefabName == prefabName);
+        Definitions.Add(new CustomMineRockDefinition(prefabName, dropItemPrefabName, sanitizedChance, sanitizedMin, sanitizedMax, sanitizedTier));
+    }
+
+    [HarmonyPatch(typeof(ZNetScene), nameof(ZNetScene.Awake))]
+    private static class ZNetSceneAwakePatch
+    {
+        private static void Postfix(ZNetScene __instance)
+        {
+            foreach (CustomMineRockDefinition definition in Definitions)
+            {
+                ConfigureMineRock(__instance, definition);
+            }
+        }
+    }
+
+    private static void ConfigureMineRock(ZNetScene scene, CustomMineRockDefinition definition)
+    {
+        GameObject? rockPrefab = scene.GetPrefab(definition.PrefabName);
+        if (rockPrefab == null)
+        {
+            TestOresIngotsPlugin.TestOresIngotsLogger.LogWarning($"Unable to find mine rock prefab '{definition.PrefabName}' when applying drop configuration.");
+            return;
+        }
+
+        GameObject? dropPrefab = scene.GetPrefab(definition.DropItemPrefabName);
+        if (dropPrefab == null)
+        {
+            TestOresIngotsPlugin.TestOresIngotsLogger.LogWarning($"Unable to find drop prefab '{definition.DropItemPrefabName}' for mine rock '{definition.PrefabName}'.");
+            return;
+        }
+
+        ItemDrop? dropItem = dropPrefab.GetComponent<ItemDrop>();
+        if (dropItem == null)
+        {
+            TestOresIngotsPlugin.TestOresIngotsLogger.LogWarning($"Prefab '{definition.DropItemPrefabName}' is missing ItemDrop component and cannot be added to mine rock '{definition.PrefabName}'.");
+            return;
+        }
+
+        DropTable dropTable = rockPrefab.GetComponent<DropTable>() ?? rockPrefab.AddComponent<DropTable>();
+        dropTable.m_dropChance = definition.DropChance;
+        dropTable.m_dropMin = definition.StackMin;
+        dropTable.m_dropMax = definition.StackMax;
+        dropTable.m_oneOfEach = false;
+        dropTable.m_drops = new List<DropTable.DropData>
+        {
+            new()
+            {
+                m_item = dropPrefab,
+                m_stackMin = definition.StackMin,
+                m_stackMax = definition.StackMax,
+                m_weight = 1f,
+                m_dropChance = 1f
+            }
+        };
+
+        MineRock? mineRock = rockPrefab.GetComponent<MineRock>();
+        if (mineRock != null)
+        {
+            FieldInfo? dropItemsField = AccessTools.Field(mineRock.GetType(), "m_dropItems");
+            dropItemsField?.SetValue(mineRock, dropTable);
+
+            FieldInfo? dropItemField = AccessTools.Field(mineRock.GetType(), "m_dropItem");
+            if (dropItemField != null)
+            {
+                object? value = dropItemField.FieldType == typeof(GameObject) ? dropPrefab : dropItemField.FieldType.IsInstanceOfType(dropItem) ? dropItem : null;
+                if (value != null)
+                {
+                    dropItemField.SetValue(mineRock, value);
+                }
+            }
+
+            FieldInfo? minToolTierField = AccessTools.Field(mineRock.GetType(), "m_minToolTier");
+            minToolTierField?.SetValue(mineRock, definition.RequiredToolTier);
+        }
+
+        Destructible? destructible = rockPrefab.GetComponent<Destructible>();
+        if (destructible != null)
+        {
+            destructible.m_minToolTier = definition.RequiredToolTier;
+        }
+    }
+}

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -44,10 +44,7 @@ namespace TestOresIngots
         {
             _serverConfigLocked = config("1 - General", "Lock Configuration", Toggle.On, "If on, the configuration is locked and can be changed by server admins only.");
             _ = ConfigSync.AddLockingConfigEntry(_serverConfigLocked);
-            
-
-
-
+            GameObject shadowRockPrefab = PrefabManager.RegisterPrefab("uooresingots", "UOminerock_shadow");
             Item UOshadow_ore = new Item("uooresingots", "UOshadow_ore");
             UOshadow_ore.Name.English("Shadow Ore");
             UOshadow_ore.Description.English("A chunk of shadow ore, pulsating with dark energy.");
@@ -57,12 +54,15 @@ namespace TestOresIngots
             UOshadow_ingot.Description.English("An ingot of shadow metal, radiating a faint dark aura.");
             UOshadow_ingot.Snapshot(); // I don't have an icon for this item in my asset bundle, so I will let the ItemManager generate one automatically
 
+            CustomMineRockRegistry.Register(shadowRockPrefab.name, "UOshadow_ore", 0.75f, 1, 4, 2);
+
             _ = new Conversion(UOshadow_ingot)
             {
                 Input = "UOshadow_ore",
                 Piece = ConversionPiece.Smelter
             };
 
+            GameObject agapiteRockPrefab = PrefabManager.RegisterPrefab("uooresingots", "UOminerock_agapite");
             Item UOagapite_ore = new Item("uooresingots", "UOagapite_ore");
             UOagapite_ore.Name.English("Agapite Ore");
             UOagapite_ore.Description.English("A chunk of agapite ore, shimmering with a silvery-blue hue.");
@@ -71,12 +71,15 @@ namespace TestOresIngots
             UOagapite_ingot.Name.English("Agapite Ingot");
             UOagapite_ingot.Description.English("An ingot of agapite metal, gleaming with a silvery-blue sheen.");
             UOagapite_ingot.Snapshot(); // I don't have an icon for this item in my asset bundle, so I will let the ItemManager generate one automatically
+            CustomMineRockRegistry.Register(agapiteRockPrefab.name, "UOagapite_ore", 0.6f, 1, 3, 2);
+
             _ = new Conversion(UOagapite_ingot)
             {
                 Input = "UOagapite_ore",
                 Piece = ConversionPiece.Smelter
             };
 
+            GameObject goldRockPrefab = PrefabManager.RegisterPrefab("uooresingots", "UOminerock_gold");
             Item UOgold_ore = new Item("uooresingots", "UOgold_ore");
             UOgold_ore.Name.English("Gold Ore");
             UOgold_ore.Description.English("A chunk of gold ore, glittering with a rich golden color.");
@@ -86,12 +89,15 @@ namespace TestOresIngots
             UOgold_ingot.Description.English("An ingot of pure gold, shining with a brilliant luster.");
             UOgold_ingot.Snapshot(); // I don't have an icon for this item in my asset bundle, so I will let the ItemManager generate one automatically
 
+            CustomMineRockRegistry.Register(goldRockPrefab.name, "UOgold_ore", 0.5f, 1, 2, 1);
+
             _ = new Conversion(UOgold_ingot)
             {
                 Input = "UOgold_ore",
                 Piece = ConversionPiece.Smelter
             };
 
+            GameObject veriteRockPrefab = PrefabManager.RegisterPrefab("uooresingots", "UOminerock_verite");
             Item UOverite_ore = new Item("uooresingots", "UOverite_ore");
             UOverite_ore.Name.English("Verite Ore");
             UOverite_ore.Description.English("A chunk of Verite ore, glowing with a mystical light.");
@@ -101,12 +107,15 @@ namespace TestOresIngots
             UOverite_ingot.Description.English("An ingot of Verite metal, pulsating with a mystical energy.");
             UOverite_ingot.Snapshot(); // I don't have an icon for this item in my asset bundle, so I will let the ItemManager generate one automatically
 
+            CustomMineRockRegistry.Register(veriteRockPrefab.name, "UOverite_ore", 0.65f, 1, 4, 2);
+
             _ = new Conversion(UOverite_ingot)
             {
                 Input = "UOverite_ore",
                 Piece = ConversionPiece.Smelter
             };
 
+            GameObject bloodrockPrefab = PrefabManager.RegisterPrefab("uooresingots", "UOminerock_bloodrock");
             Item UObloodrock_ore = new Item("uooresingots", "UObloodrock_ore");
             UObloodrock_ore.Name.English("Bloodrock Ore");
             UObloodrock_ore.Description.English("A chunk of bloodrock ore, radiating a deep red glow.");
@@ -116,12 +125,15 @@ namespace TestOresIngots
             UObloodrock_ingot.Description.English("An ingot of bloodrock metal, emanating a powerful red aura.");
             UObloodrock_ingot.Snapshot(); // I don't have an icon for this item in my asset bundle, so I will let the ItemManager generate one automatically
 
+            CustomMineRockRegistry.Register(bloodrockPrefab.name, "UObloodrock_ore", 0.7f, 1, 3, 2);
+
             _ = new Conversion(UObloodrock_ingot)
             {
                 Input = "UObloodrock_ore",
                 Piece = ConversionPiece.Smelter
             };
 
+            GameObject blackrockPrefab = PrefabManager.RegisterPrefab("uooresingots", "UOminerock_blackrock");
             Item UOblackrock_ore = new Item("uooresingots", "UOblackrock_ore");
             UOblackrock_ore.Name.English("Blackrock Ore");
             UOblackrock_ore.Description.English("A chunk of blackrock ore, absorbing light around it.");
@@ -131,12 +143,15 @@ namespace TestOresIngots
             UOblackrock_ingot.Description.English("An ingot of blackrock metal, exuding a dark and mysterious aura.");
             UOblackrock_ingot.Snapshot(); // I don't have an icon for this item in my asset bundle, so I will let the ItemManager generate one automatically
 
+            CustomMineRockRegistry.Register(blackrockPrefab.name, "UOblackrock_ore", 0.55f, 1, 3, 2);
+
             _ = new Conversion(UOblackrock_ingot)
             {
                 Input = "UOblackrock_ore",
                 Piece = ConversionPiece.Smelter
             };
 
+            GameObject snowRockPrefab = PrefabManager.RegisterPrefab("uooresingots", "UOminerock_snow");
             Item UOsnow_ore = new Item("uooresingots", "UOsnow_ore");
             UOsnow_ore.Name.English("Snow Ore");
             UOsnow_ore.Description.English("A chunk of snow ore, cold to the touch and shimmering with icy crystals.");
@@ -146,12 +161,15 @@ namespace TestOresIngots
             UOsnow_ingot.Description.English("An ingot of snow metal, radiating a chilling coldness.");
             UOsnow_ingot.Snapshot(); // I don't have an icon for this item in my asset bundle, so I will let the ItemManager generate one automatically
 
+            CustomMineRockRegistry.Register(snowRockPrefab.name, "UOsnow_ore", 0.65f, 1, 4, 1);
+
             _ = new Conversion(UOsnow_ingot)
             {
                 Input = "UOsnow_ore",
                 Piece = ConversionPiece.Smelter
             };
 
+            GameObject iceRockPrefab = PrefabManager.RegisterPrefab("uooresingots", "UOminerock_ice");
             Item UOice_ore = new Item("uooresingots", "UOice_ore");
             UOice_ore.Name.English("Ice Ore");
             UOice_ore.Description.English("A chunk of ice ore, frozen solid and sparkling with frost.");
@@ -160,6 +178,8 @@ namespace TestOresIngots
             UOice_ingot.Name.English("Ice Ingot");
             UOice_ingot.Description.English("An ingot of ice metal, emanating an intense cold.");
             UOice_ingot.Snapshot(); // I don't have an icon for this item in my asset bundle, so I will let the ItemManager generate one automatically
+
+            CustomMineRockRegistry.Register(iceRockPrefab.name, "UOice_ore", 0.55f, 1, 3, 1);
 
             _ = new Conversion(UOice_ingot)
             {

--- a/TestOresIngots.csproj
+++ b/TestOresIngots.csproj
@@ -113,6 +113,7 @@
   <ItemGroup>
     <Compile Include="ItemManager.cs" />
     <Compile Include="LocalizationManager.cs" />
+    <Compile Include="CustomMineRockRegistry.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VersionHandshake.cs" />


### PR DESCRIPTION
## Summary
- register each custom ore mine rock prefab from the asset bundle and associate it with its ore item
- add a reusable registry that wires up drop tables, tool tiers, and drop odds when the ZNet scene loads
- include the new registry file in the project build

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ddc8f4b4f48328a4d8032e25fdc15b